### PR TITLE
Simplify IR sector display handling

### DIFF
--- a/defence.py
+++ b/defence.py
@@ -178,32 +178,10 @@ def main():
 
         if strength < HOLDING_BALL_THRESHOLD:
             touching = False
-            if ir == 0:
+            if 1 <= ir <= 12:
+                hub.display.number(ir)
+            else:
                 hub.display.char("C")
-            elif ir == 1:
-                hub.display.number(1)
-            elif ir == 2:
-                hub.display.number(2)
-            elif ir == 3:
-                hub.display.number(3)
-            elif ir == 4:
-                hub.display.number(4)
-            elif ir == 5:
-                hub.display.number(5)
-            elif ir == 6:
-                hub.display.number(6)
-            elif ir == 7:
-                hub.display.number(7)
-            elif ir == 8:
-                hub.display.number(8)
-            elif ir == 9:
-                hub.display.number(9)
-            elif ir == 10:
-                hub.display.number(10)
-            elif ir == 11:
-                hub.display.number(11)
-            elif ir == 12:
-                hub.display.number(12)
         if distance < 0:
             distance = 200
         if distance <= DIST_TOUCHING:

--- a/striker.py
+++ b/striker.py
@@ -184,51 +184,15 @@ def main():
         message_to_broadcast = None
 
         dir, strength = Ir_Read_360_Sensor_Data(4)
-        if dir == 0:
+        if 1 <= dir <= 18:
+            hub.display.number(dir)
+        else:
             hub.display.char("C")
             move(finalDirection, MEDIUM_SPEED)
             hub.light.on(Color.VIOLET)
             continue
-        # --- skip when no IR signal ---
 
         distance = us.distance() / 10
-
-        if dir == 1:
-            hub.display.number(1)
-        elif dir == 2:
-            hub.display.number(2)
-        elif dir == 3:
-            hub.display.number(3)
-        elif dir == 4:
-            hub.display.number(4)
-        elif dir == 5:
-            hub.display.number(5)
-        elif dir == 6:
-            hub.display.number(6)
-        elif dir == 7:
-            hub.display.number(7)
-        elif dir == 8:
-            hub.display.number(8)
-        elif dir == 9:
-            hub.display.number(9)
-        elif dir == 10:
-            hub.display.number(10)
-        elif dir == 11:
-            hub.display.number(11)
-        elif dir == 12:
-            hub.display.number(12)
-        elif dir == 13:
-            hub.display.number(13)
-        elif dir == 14:
-            hub.display.number(14)
-        elif dir == 15:
-            hub.display.number(15)
-        elif dir == 16:
-            hub.display.number(16)
-        elif dir == 17:
-            hub.display.number(17)
-        elif dir == 18:
-            hub.display.number(18)
 
         speed = MAX_SPEED
         if strength > HIGH_STRENGTH:

--- a/strikerIR.py
+++ b/strikerIR.py
@@ -101,52 +101,14 @@ def main():
             continue
 
         dir, str = Ir_Read_360_Sensor_Data(4)
-        if dir == 0:
+        if 1 <= dir <= 18:
+            hub.display.number(dir)
+        else:
             hub.display.char("C")
             hub.light.on(Color.VIOLET)
             continue
-        # --- skip when no IR signal ---
 
         distance = us.distance() / 10
-
-        if dir == 0:
-            hub.display.char("C")
-        elif dir == 1:
-            hub.display.number(1)
-        elif dir == 2:
-            hub.display.number(2)
-        elif dir == 3:
-            hub.display.number(3)
-        elif dir == 4:
-            hub.display.number(4)
-        elif dir == 5:
-            hub.display.number(5)
-        elif dir == 6:
-            hub.display.number(6)
-        elif dir == 7:
-            hub.display.number(7)
-        elif dir == 8:
-            hub.display.number(8)
-        elif dir == 9:
-            hub.display.number(9)
-        elif dir == 10:
-            hub.display.number(10)
-        elif dir == 11:
-            hub.display.number(11)
-        elif dir == 12:
-            hub.display.number(12)
-        elif dir == 13:
-            hub.display.number(13)
-        elif dir == 14:
-            hub.display.number(14)
-        elif dir == 15:
-            hub.display.number(15)
-        elif dir == 16:
-            hub.display.number(16)
-        elif dir == 17:
-            hub.display.number(17)
-        elif dir == 18:
-            hub.display.number(18)
 
         print([dir, "speed", str, finalDirection])
         wait(LOOP_DELAY_MS) # Delay


### PR DESCRIPTION
## Summary
- Replace long IR sector display chains with concise range checks in defence, striker, and strikerIR controllers.
- Show a generic "C" when the signal is out of range.

## Testing
- `python -m py_compile defence.py striker.py strikerIR.py`


------
https://chatgpt.com/codex/tasks/task_e_68b04141678083338e52df004fb4e095