### PR TITLE
Add Graph

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -1,0 +1,243 @@
+"""Plot motor speed and heading data collected from strikerforward.py."""
+
+import ast
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+import matplotlib.pyplot as plt
+
+DEFAULT_SAMPLE_INTERVAL_MS = 10.0
+HEADING_DRIFT_THRESHOLD_DEG = 10.0
+MOTOR_ORDER = ("E", "A", "C", "D")
+MOTOR_COLORS = {
+    "E": "tab:blue",
+    "A": "tab:orange",
+    "C": "tab:green",
+    "D": "tab:red",
+}
+
+
+def _safe_literal_eval(raw: str) -> Any:
+    """Attempt to parse a Python literal, allowing for prefixed text."""
+
+    literal_text = raw.strip()
+
+    try:
+        return ast.literal_eval(literal_text)
+    except (SyntaxError, ValueError) as exc:
+        start_index = literal_text.find("{")
+        end_index = literal_text.rfind("}")
+        if start_index != -1 and end_index != -1 and end_index > start_index:
+            snippet = literal_text[start_index : end_index + 1]
+            try:
+                return ast.literal_eval(snippet)
+            except (SyntaxError, ValueError) as inner_exc:  # pragma: no cover - helper
+                raise ValueError("Input could not be parsed as a Python literal.") from inner_exc
+        raise ValueError("Input could not be parsed as a Python literal.") from exc
+
+
+def _normalize_sample_map(raw_map: Mapping[Any, Iterable]) -> Dict[str, List[float]]:
+    """Validate and convert a mapping of motor labels to numeric samples."""
+
+    processed: Dict[str, List[float]] = {}
+
+    for motor, values in raw_map.items():
+        if not isinstance(values, Iterable) or isinstance(values, (str, bytes)):
+            raise ValueError(
+                "Each dictionary value must be a list or tuple of numeric samples."
+            )
+
+        processed[str(motor)] = [float(value) for value in values]
+
+    return processed
+
+
+def _parse_run_data(
+    raw: str,
+) -> (Dict[str, List[float]], Optional[float], Optional[float], Optional[List[float]]):
+    """Parse the CLI input into samples and optional metadata."""
+
+    try:
+        data = _safe_literal_eval(raw)
+    except ValueError as exc:  # pragma: no cover - interactive message
+        raise ValueError("Input could not be parsed as a Python literal.") from exc
+
+    if not isinstance(data, Mapping):
+        raise ValueError("Input must be a dictionary of samples or run metadata.")
+
+    if "speed_samples" in data:
+        speed_section = data["speed_samples"]
+        if not isinstance(speed_section, Mapping):
+            raise ValueError("`speed_samples` must be a mapping of motor labels to lists.")
+
+        samples = _normalize_sample_map(speed_section)
+
+        sample_interval_ms: Optional[float]
+        if "sample_interval_ms" in data:
+            sample_interval_ms = float(data["sample_interval_ms"])
+        else:
+            sample_interval_ms = None
+
+        reference_speed: Optional[float]
+        if "reference_speed" in data:
+            reference_speed = float(data["reference_speed"])
+        else:
+            reference_speed = None
+
+        heading_samples: Optional[List[float]] = None
+        if "heading_samples" in data:
+            heading_section = data["heading_samples"]
+            if not isinstance(heading_section, Iterable) or isinstance(
+                heading_section, (str, bytes)
+            ):
+                raise ValueError("`heading_samples` must be a list of numeric values.")
+            heading_samples = [float(value) for value in heading_section]
+
+        return samples, sample_interval_ms, reference_speed, heading_samples
+
+    samples = _normalize_sample_map(data)
+    return samples, None, None, None
+
+
+def main() -> None:
+    """Collect user input and plot the provided speed samples."""
+
+    raw_samples = input(
+        "Paste the run data dictionary produced by strikerforward.py and press Enter:\n"
+    )
+
+    try:
+        samples, provided_interval, reference_speed, heading_samples = _parse_run_data(
+            raw_samples
+        )
+    except ValueError as error:  # pragma: no cover - interactive message
+        print(error)
+        return
+
+    interval_default = (
+        provided_interval if provided_interval is not None else DEFAULT_SAMPLE_INTERVAL_MS
+    )
+    sample_interval_text = input(
+        (
+            "Enter the sampling interval in milliseconds "
+            f"[default: {interval_default}]: "
+        )
+    ).strip()
+
+    if sample_interval_text:
+        try:
+            sample_interval_ms = float(sample_interval_text)
+        except ValueError:  # pragma: no cover - interactive message
+            print("Sampling interval must be a number.")
+            return
+    else:
+        sample_interval_ms = interval_default
+
+    if reference_speed is not None:
+        reference_prompt = (
+            "Enter the reference speed (deg/s) [default: {}]: ".format(reference_speed)
+        )
+    else:
+        reference_prompt = "Enter the reference speed (deg/s) [optional]: "
+    reference_text = input(reference_prompt).strip()
+    if reference_text:
+        try:
+            reference_speed = float(reference_text)
+        except ValueError:  # pragma: no cover - interactive message
+            print("Reference speed must be a number.")
+            return
+
+    if heading_samples is None:
+        heading_text = input(
+            "Enter heading samples as a Python list (optional, used for drift marker): "
+        ).strip()
+        if heading_text:
+            try:
+                parsed_heading = _safe_literal_eval(heading_text)
+            except ValueError:  # pragma: no cover - interactive message
+                print("Heading samples could not be parsed as a Python list.")
+                return
+
+            if not isinstance(parsed_heading, Iterable) or isinstance(
+                parsed_heading, (str, bytes)
+            ):
+                print("Heading samples must be provided as a list of numbers.")
+                return
+
+            heading_samples = [float(value) for value in parsed_heading]
+
+    ordered_samples: List[List[float]] = []
+    for motor in MOTOR_ORDER:
+        if motor in samples:
+            ordered_samples.append(samples[motor])
+
+    if not ordered_samples:
+        print("No valid motor data found in the provided input.")
+        return
+
+    sample_lengths = {len(values) for values in ordered_samples}
+    if len(sample_lengths) != 1:
+        print("All motors must have the same number of samples.")
+        return
+
+    sample_count = sample_lengths.pop()
+    if sample_count == 0:
+        print("No samples found for the provided motors.")
+        return
+    times = [(index * sample_interval_ms) / 1000.0 for index in range(sample_count)]
+
+    plt.figure()
+    for motor in MOTOR_ORDER:
+        if motor not in samples:
+            continue
+
+        plt.plot(times, samples[motor], label=f"Motor {motor}", color=MOTOR_COLORS.get(motor))
+
+    if reference_speed is not None:
+        plt.axhline(
+            reference_speed,
+            color="black",
+            linestyle="--",
+            linewidth=1,
+            label="Reference speed",
+        )
+
+    drift_index: Optional[int] = None
+    if heading_samples:
+        compare_count = min(len(heading_samples), sample_count)
+        baseline_heading = heading_samples[0]
+        for index in range(compare_count):
+            if abs(heading_samples[index] - baseline_heading) > HEADING_DRIFT_THRESHOLD_DEG:
+                drift_index = index
+                break
+
+        if drift_index is not None:
+            drift_time = times[min(drift_index, len(times) - 1)]
+            plt.axvline(
+                drift_time,
+                color="black",
+                linestyle=":",
+                linewidth=1,
+                label="Heading drift threshold",
+            )
+        elif len(heading_samples) < sample_count:
+            print(
+                "Heading samples shorter than speed samples; unable to mark drift threshold."
+            )
+        else:
+            print(
+                "Heading never exceeded the drift threshold during the sampled window."
+            )
+    elif heading_samples == []:
+        print("No heading data provided; skipping drift marker.")
+
+    plt.title("Motor speed over time")
+    plt.xlabel("Time (s)")
+    plt.ylabel("Speed (deg/s)")
+    plt.grid(True)
+    plt.legend()
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/strikerforward.py
+++ b/strikerforward.py
@@ -8,8 +8,12 @@ from pybricks.iodevices import PUPDevice
 MAX_SPEED = 1050
 MAX_ACCELERATION = 2000
 
+RUN_DURATION_MS = 5000
+SAMPLE_INTERVAL_MS = 10
+SAMPLED_MOTOR_PORTS = (Port.E, Port.A, Port.C, Port.D)
+
 QUADRANT_FUNCS = [
-    #E, F, C, D
+    # E, A, C, D
     lambda r: (1-r, -1, 1, r-1),    # 0°-89° N → E
     lambda r: (-1, r-1, 1-r, 1),    # 90°-179° E → S
     lambda r: (r-1, 1, -1, 1-r),    # 180°-269° S → W
@@ -21,21 +25,36 @@ QUADRANT_FUNCS = [
 # --------------------------------------------
 
 e_motor = Motor(Port.E)
-f_motor = Motor(Port.A)
+a_motor = Motor(Port.A)
 c_motor = Motor(Port.C)
 d_motor = Motor(Port.D)
 ir_sensor = PUPDevice(Port.B)
 us = UltrasonicSensor(Port.F)
+hub = PrimeHub()
+
+PORT_TO_MOTOR = {
+    Port.E: e_motor,
+    Port.A: a_motor,
+    Port.C: c_motor,
+    Port.D: d_motor,
+}
+
+PORT_LABELS = {
+    Port.E: "E",
+    Port.A: "A",
+    Port.C: "C",
+    Port.D: "D",
+}
 
 
-print(f_motor.control.limits())
+print(a_motor.control.limits())
 e_motor.control.limits(MAX_SPEED, MAX_ACCELERATION)
-f_motor.control.limits(MAX_SPEED, MAX_ACCELERATION)
+a_motor.control.limits(MAX_SPEED, MAX_ACCELERATION)
 c_motor.control.limits(MAX_SPEED, MAX_ACCELERATION)
 d_motor.control.limits(MAX_SPEED, MAX_ACCELERATION)
 
 # e_motor.control.pid(21242, 21242, 10620, 8, 15)
-# f_motor.control.pid(21242, 21242, 10620, 8, 15)
+# a_motor.control.pid(21242, 21242, 10620, 8, 15)
 # c_motor.control.pid(21242, 21242, 10620, 8, 15)
 # d_motor.control.pid(21242, 21242, 10620, 8, 15)
 
@@ -49,18 +68,45 @@ def move(direction: int, speed: int):
     # --- Lookup table for quadrant vectors ---
     quadrant = (direction % 360) // 90
     ratio = (direction % 90) / 45
-    e_mult, f_mult, c_mult, d_mult = QUADRANT_FUNCS[quadrant](ratio)
+    e_mult, a_mult, c_mult, d_mult = QUADRANT_FUNCS[quadrant](ratio)
     e_value = int(e_mult * speed)
-    f_value = int(f_mult * speed)
+    a_value = int(a_mult * speed)
     c_value = int(c_mult * speed)
     d_value = int(d_mult * speed)
 
     e_motor.run(e_value)
-    f_motor.run(f_value)
+    a_motor.run(a_value)
     c_motor.run(c_value)
     d_motor.run(d_value)
 
-while True:
+speed_samples = {port: [] for port in SAMPLED_MOTOR_PORTS}
+heading_samples = []
+timer = StopWatch()
+timer.reset()
+
+hub.imu.reset_heading(0)
+
+while timer.time() < RUN_DURATION_MS:
     move(0, MAX_SPEED)
-    print(e_motor.speed(), f_motor.speed(), c_motor.speed(), d_motor.speed())
-    wait(10)
+    heading = hub.imu.heading("3D")
+    heading = ((heading + 180) % 360) - 180
+    heading_samples.append(heading)
+    for port in SAMPLED_MOTOR_PORTS:
+        speed_samples[port].append(PORT_TO_MOTOR[port].speed())
+    wait(SAMPLE_INTERVAL_MS)
+
+e_motor.stop()
+a_motor.stop()
+c_motor.stop()
+d_motor.stop()
+
+run_data = {
+    "sample_interval_ms": SAMPLE_INTERVAL_MS,
+    "reference_speed": MAX_SPEED,
+    "heading_samples": heading_samples,
+    "speed_samples": {
+        PORT_LABELS[port]: samples for port, samples in speed_samples.items()
+    },
+}
+
+print("Run data:", run_data)


### PR DESCRIPTION
## Summary
- sample robot heading during strikerforward runs and include metadata alongside motor speeds
- extend graph.py to parse the richer run data, overlay the reference speed, and mark when heading drift exceeds 10°

## Testing
- python -m compileall graph.py

------
https://chatgpt.com/codex/tasks/task_e_68d665278cd88333a74c0ebce242adca